### PR TITLE
Disable autocorrect and autocapitalize on input field

### DIFF
--- a/index.html
+++ b/index.html
@@ -270,7 +270,7 @@
             <div class="form-group input-fields">
                 <label class="col-form-label col-form-label-lg"></label>
                 <input v-model="typedPhrase" :class="{'form-control': true, 'form-control-lg': true, 'incorrect-input': !isInputCorrect}"
-                    id="input-typing" type="text" placeholder="Re-type if failed, press <TAB> or <ESC> to reset" spellcheck="false" v-on:keyup="keyHandler"
+                    id="input-typing" type="text" autocorrect="off" autocapitalize="none" placeholder="Re-type if failed, press <TAB> or <ESC> to reset" spellcheck="false" v-on:keyup="keyHandler"
                 >
             </div>
         </div>


### PR DESCRIPTION
To work correctly on mobile devices this disables autocorrect and autocapitalize for the input field. Otherwise e.g. iOS will capitalise the first letter typed.