### PR TITLE
Make trailing spaces count as errors

### DIFF
--- a/index.html
+++ b/index.html
@@ -804,7 +804,7 @@
                         this.isInputCorrect = true;
                         this.hitsCorrect += 1;
                     }
-                    else {
+                    else if (this.expectedPhrase !== typedPhrase.replace(/ +$/, "")) {
                         if (this.data.soundIncorrectLetterEnabled) {
                             this.stopCurrentPlayingSound();
                             this.incorrectLetterSound.play();
@@ -814,10 +814,7 @@
                         this.hitsWrong += 1;
                     }
 
-                    if (
-                        typedPhrase.length === this.expectedPhrase.length
-                        && typedPhrase === this.expectedPhrase
-                    ) {
+                    if (typedPhrase.replace(/ +$/, "") === this.expectedPhrase) {
                         var currentTime = new Date().getTime() / 1000;
                         this.rawWPM = Math.round(
                             // 5 chars equals 1 word.

--- a/index.html
+++ b/index.html
@@ -786,9 +786,9 @@
                         return;
                     }
 
-                    // Remove spaces at both ends of the phrase
+                    // Remove spaces at starting of the phrase
                     // which might be accidentally typed.
-                    var typedPhrase = this.typedPhrase.trim();
+                    var typedPhrase = this.typedPhrase.replace(/^ +/, "");
                     if (!typedPhrase.length) {
                         return;
                     }


### PR DESCRIPTION
fixes the problem when you type space at the end and it doesn't count as error until you have typed the next word, which fells very buggy.

For Example:
```
*-------------------*
* ll hi ll hi ll hi *
*-------------------*

ll_h_
```
won't count as error, until this much is typed:
```
ll_h_i
```