### PR TITLE
Update readme to link the French version of ngram-type

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,4 +85,9 @@ You could access the online version using GitHub Pages:
     - https://github.com/aleuxser/ngram-type-ru/
   - Hosted Version:
     - https://aleuxser.github.io/ngram-type-ru/
+- French
+  - Project Page:
+    - https://github.com/edmundlam/ngram-type-fr/
+  - Hosted Version:
+    - https://edmundlam.github.io/ngram-type-fr/
 


### PR DESCRIPTION
Hello @ranelpadon,

I have forked the original repo and created a french version that includes french n-grams.

This PR adds links to the fork and the hosted version.

Would you be willing to add it to the readme of your original ngram-type?

Note that I kept the "Buy me a Coffee" pointing to your link, since it is your original work 😉 