### PR TITLE
Fix page hanging on certain combination values

### DIFF
--- a/app.js
+++ b/app.js
@@ -243,6 +243,11 @@ var ngramTypeConfig = {
         },
         refreshPhrases: function() {
             var dataSource = this.dataSource;
+
+            if (dataSource.combination < 1) {
+                dataSource.combination = 1
+            }
+
             dataSource.phrases = this.generatePhrases(dataSource.combination, dataSource.repetition);
             this.expectedPhrase = dataSource.phrases[0];
             dataSource.phrasesCurrentIndex = 0;


### PR DESCRIPTION
Closes #31.

Minimal change which fixing the error by moving the value back into the range if it's below the minimum. Open to changing if another behavior would be preferred.