### PR TITLE
Replace lookalike chars

### DIFF
--- a/app.js
+++ b/app.js
@@ -318,6 +318,14 @@ var ngramTypeConfig = {
 
             this.resumeTimer();
 
+            var substitutions = [
+                ["’", "'"],
+                [" ", " "],
+            ];
+            for (var subst of substitutions) {
+                typedPhrase = typedPhrase.replaceAll(subst[0], subst[1]);
+            }
+
             if (this.expectedPhrase.startsWith(typedPhrase)) {
                 if (this.data.soundCorrectLetterEnabled) {
                     this.stopCurrentPlayingSound();


### PR DESCRIPTION
In french ’ is more correct than ' but only easily achiveable on specific keyboard layout. The exercices of [ngram-types fr](https://github.com/edmundlam/ngram-type-fr/) are using '

Replace non-breaking space by space
