### PR TITLE
Master

### DIFF
--- a/index.html
+++ b/index.html
@@ -329,7 +329,7 @@
                     :class="{'form-control': true, 'form-control-lg': true, 'incorrect-input': !isInputCorrect}"
                     id="input-typing" type="text" autocorrect="off" autocapitalize="none"
                     placeholder="Re-type if failed, press <TAB> or <ESC> to reset" spellcheck="false"
-                    v-on:keyup="keyHandler">
+                    v-on:keydown="keyHandler">
             </div>
         </div>
         <!--Lesson end-->


### PR DESCRIPTION
Fixed an issue resulting in skewed WPM number.

The `keyHandler` function was executed on keyup event. This created a de-sync with `typedPhrase` content (as input stores result on keydown).

See the observed values when typing word `increase`:

event key | typedPhrase
--------- | ------------
i         | i
n         | inc
c         | incr
r         | increa
e         | increas
s         | increase
e         | 

The test finishes on key `s` counting only 6 out of 7 typed characters towards WPM :
> https://github.com/ranelpadon/ngram-type/blob/b31347e82df2e8cc6167b7e09fef0a58ce38f4f7/app.js#L344