### PR TITLE
Adaptive training mode

### DIFF
--- a/app.css
+++ b/app.css
@@ -19,8 +19,17 @@ body {
     max-width: 10rem;
 }
 
-.generator-settings-module {
-    max-width: 25rem;
+.ema-settings-module {
+    max-width: 12rem;
+}
+
+.ema-settings-group-label {
+    margin: 0.65rem 0 0.15rem;
+    font-size: 0.7rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: rgba(255, 255, 255, 0.45);
 }
 
 .card-body {

--- a/app.css
+++ b/app.css
@@ -19,6 +19,10 @@ body {
     max-width: 10rem;
 }
 
+.generator-settings-module {
+    max-width: 25rem;
+}
+
 .card-body {
     /*             margin-top: 20px;
     min-height: 480px; */

--- a/app.js
+++ b/app.js
@@ -20,11 +20,14 @@ var ngramTypeConfig = {
                 soundPassedThresholdEnabled: true,
                 soundFailedThresholdEnabled: true,
                 lessonGenerationMode: 'random',
-                ema: {
-                    genBias: 1,
+                emaLearningConfig: {
                     alpha: 0.2,
-                    mistakeWeight: 1,
-                    consistencyWeight: 1.5,
+                },
+                emaGenerationConfig: {
+                    generalBias: 1,
+                    speedBias: 1,
+                    mistakesBias: 1,
+                    consistencyBias: 1,
                 },
                 bigrams: {
                     scope: 50,
@@ -35,7 +38,9 @@ var ngramTypeConfig = {
                     WPMs: [],
                     phrases: {},
                     phrasesCurrentIndex: 0,
-                    ngramEmaMs: {},
+                    charsTypedCount: 0,
+                    lastMistakeGlobalIndex: {},
+                    emaScores: {},
                 },
                 trigrams: {
                     scope: 50,
@@ -46,7 +51,9 @@ var ngramTypeConfig = {
                     WPMs: [],
                     phrases: {},
                     phrasesCurrentIndex: 0,
-                    ngramEmaMs: {},
+                    charsTypedCount: 0,
+                    lastMistakeGlobalIndex: {},
+                    emaScores: {},
                 },
                 tetragrams: {
                     scope: 50,
@@ -57,7 +64,9 @@ var ngramTypeConfig = {
                     WPMs: [],
                     phrases: {},
                     phrasesCurrentIndex: 0,
-                    ngramEmaMs: {},
+                    charsTypedCount: 0,
+                    lastMistakeGlobalIndex: {},
+                    emaScores: {},
                 },
                 words: {
                     scope: 50,
@@ -68,7 +77,9 @@ var ngramTypeConfig = {
                     WPMs: [],
                     phrases: {},
                     phrasesCurrentIndex: 0,
-                    ngramEmaMs: {},
+                    charsTypedCount: 0,
+                    lastMistakeGlobalIndex: {},
+                    emaScores: {},
                 },
                 custom_words: {
                     scope: null,
@@ -79,7 +90,9 @@ var ngramTypeConfig = {
                     WPMs: [],
                     phrases: {},
                     phrasesCurrentIndex: 0,
-                    ngramEmaMs: {},
+                    charsTypedCount: 0,
+                    lastMistakeGlobalIndex: {},
+                    emaScores: {},
                 },
             },
 
@@ -154,6 +167,7 @@ var ngramTypeConfig = {
             if (key == 'Tab' || key == 'Escape') {
                 e.preventDefault();
                 that.resetCurrentPhraseMetrics();
+                that.pauseTimer(); 
             }
         });
 
@@ -193,20 +207,27 @@ var ngramTypeConfig = {
             this.save();
         },
         'data.lessonGenerationMode': function() {
-            this.refreshPhrasesAndCurrentMetrics();
-        },
-        'data.ema.genBias': function() {
             this.save();
             this.refreshPhrasesAndCurrentMetrics();
         },
-        'data.ema.alpha': function() {
+        'data.emaLearningConfig.alpha': function() {
             this.save();
         },
-        'data.ema.mistakeWeight': function() {
+        'data.emaGenerationConfig.generalBias': function() {
             this.save();
+            this.refreshPhrasesAndCurrentMetrics();
         },
-        'data.ema.consistencyWeight': function() {
+        'data.emaGenerationConfig.speedBias': function() {
             this.save();
+            this.refreshPhrasesAndCurrentMetrics();
+        },
+        'data.emaGenerationConfig.mistakesBias': function() {
+            this.save();
+            this.refreshPhrasesAndCurrentMetrics();
+        },
+        'data.emaGenerationConfig.consistencyBias': function() {
+            this.save();
+            this.refreshPhrasesAndCurrentMetrics();
         },
         custom_words: function() {
             this.refreshPhrasesAndCurrentMetrics();
@@ -258,31 +279,61 @@ var ngramTypeConfig = {
             ) {
                 this.data.lessonGenerationMode = 'random';
             }
-            this.data.ema ||= {};
-            this.data.ema.genBias ||= 1;
-            this.data.ema.alpha ||= 0.2;
-            this.data.ema.mistakeWeight ||= 1;
-            this.data.ema.consistencyWeight ||= 1.5;
+            this.data.emaLearningConfig ||= {};
+            this.data.emaLearningConfig.alpha ||= 0.2;
+            this.data.emaLearningConfig.mistakeWeight ||= 1;
+            this.data.emaLearningConfig.consistencyWeight ||= 1.5;
+
+            this.data.emaGenerationConfig ||= {};
+            this.data.emaGenerationConfig.generalBias ||= 1;
+            this.data.emaGenerationConfig.speedBias ||= 1;
+            this.data.emaGenerationConfig.mistakesBias ||= 1;
+            this.data.emaGenerationConfig.consistencyBias ||= 1;
         },
-        normalizeGenerationScore: function (raw) {
-            if (
-                raw === Infinity
-                || raw === Number.POSITIVE_INFINITY
-                || typeof raw !== 'number'
-                || raw !== raw
-            ) {
-                return 1e300;
-            }
-            return Math.max(raw, 1e-9);
+        inclusivePercentile: function (sortedValues, k) {
+            var realIndex = k * (sortedValues.length - 1);
+            var index = Math.floor(realIndex);
+            var fracIndex = realIndex - index;
+            var fracScore = index + 1 < sortedValues.length ? fracIndex * (sortedValues[index + 1] - sortedValues[index]) : 0;
+            return sortedValues[index] + fracScore;
         },
-        
-        getGenerationEmaScore: function (ngramStr) {
-            var ds = this.dataSource;
-            var map = ds.ngramEmaMs ||= {};
-            if (!Object.prototype.hasOwnProperty.call(map, ngramStr)) {
-                return Infinity;
+        normalizeScore: function (score, sortedScores, minPercentile, maxPercentile) {
+            var medianScore = this.inclusivePercentile(sortedScores, 0.5);
+            var minDistance = minPercentile - medianScore;
+            var maxDistance = maxPercentile - medianScore;
+            if (maxDistance + minDistance === 0) {
+                return 0;
             }
-            return map[ngramStr];
+            var distance = score - medianScore;
+            return (distance - minDistance) / Math.abs(maxDistance - minDistance);
+        },
+        getWeights: function (ngram) {
+            var emaScores = this.dataSource.emaScores || {};
+            if (!Object.prototype.hasOwnProperty.call(emaScores, ngram)) {
+                return {
+                    durationFactor: 1e300,
+                    mistakesFactor: 1e300,
+                    consistencyFactor: 1e300,
+                };
+            }
+            var sortedDurations = Object.values(emaScores).map((score) => score.duration).sort((a, b) => a - b);
+            var sortedMistakes = Object.values(emaScores).map((score) => score.mistakes).sort((a, b) => a - b);
+            var sortedConsistencies = Object.values(emaScores).map((score) => score.consistency).sort((a, b) => a - b);
+            
+            var k = 0.05;
+            var durationFactor = this.normalizeScore(emaScores[ngram].duration, sortedDurations, this.inclusivePercentile(sortedDurations, k), this.inclusivePercentile(sortedDurations, 1 - k));
+            var mistakesFactor = 1 - this.normalizeScore(emaScores[ngram].mistakes, sortedMistakes, this.inclusivePercentile(sortedMistakes, k), this.inclusivePercentile(sortedMistakes, 1 - k));
+            var consistencyFactor = this.normalizeScore(emaScores[ngram].consistency, sortedConsistencies, this.inclusivePercentile(sortedConsistencies, k), this.inclusivePercentile(sortedConsistencies, 1 - k));
+            return {
+                durationFactor: durationFactor,
+                mistakesFactor: mistakesFactor,
+                consistencyFactor: consistencyFactor,
+            };
+        },
+        getCombinedWeight: function (ngram) {
+            var weights = this.getWeights(ngram);
+            var weight = weights.durationFactor * this.data.emaGenerationConfig.speedBias + weights.mistakesFactor * this.data.emaGenerationConfig.mistakesBias + weights.consistencyFactor * this.data.emaGenerationConfig.consistencyBias;
+            return Math.pow(weight, this.data.emaGenerationConfig.generalBias);
         },
         weightedPickIndex: function (weights) {
             var sum = 0;
@@ -305,17 +356,13 @@ var ngramTypeConfig = {
         sampleNgramsWeightedNoReplace: function (pool, count) {
             var out = [];
             var that = this;
-            var poolCopy = pool; // no need to deep copy, we don't mutate elements
-            var take = Math.min(count, poolCopy.length);
+            var take = Math.min(count, pool.length);
             for (var t = 0; t < take; t++) {
-                var weights = poolCopy.map(function (ng) {
-                    return that.normalizeGenerationScore(
-                        Math.pow(that.getGenerationEmaScore(ng), that.data.ema.genBias)
-                    );
+                var weights = pool.map(function (ngram) {
+                    return that.getCombinedWeight(ngram);
                 });
                 var idx = this.weightedPickIndex(weights);
-                out.push(poolCopy[idx]);
-                // poolCopy.splice(idx, 1);
+                out.push(pool[idx]);
             }
             return out;
         },
@@ -340,19 +387,13 @@ var ngramTypeConfig = {
             return [parts.join(' ')];
         },
         tokenizePhrase: function (expectedPhrase) {
-            var tokenList = expectedPhrase.split(/\s+/).filter(function (t) {
-                return t.length > 0;
-            });
+            var tokenList = expectedPhrase.match(/\s*\S*\s?/g).filter(t => t.length > 0);
             var tokens = [];
             var pos = 0;
             for (var i = 0; i < tokenList.length; i++) {
-                var token = tokenList[i];
+                var token = tokenList[i].trimEnd();
                 tokens.push({ text: token, start: pos, end: pos + token.length - 1 });
-                pos += token.length;
-                if (i < tokenList.length - 1) {
-                    // Adds a space between tokens.
-                    pos += 1;
-                }
+                pos += tokenList[i].length;
             }
             return tokens;
         },
@@ -367,6 +408,17 @@ var ngramTypeConfig = {
             this.tokenStartMs = Array(n).fill(null);
             this.tokenEndMs = Array(n).fill(null);
             this.lastValidPrefixLength = 0;
+        },
+        updateMistakeTracking: function () {
+            var ds = this.dataSource;
+            for (var i = 0; i < this.tokens.length; i++) {
+                var token = this.tokens[i];
+                if (this.tokenWrongCounts[i] > 0) {
+                    var phraseStartGlobalIndex = ds.charsTypedCount - (this.hitsWrong + this.hitsCorrect);
+                    var tokenEndGlobalIndex = phraseStartGlobalIndex + token.end; // for simplicity, we assume all ngrams before this one are typed without mistakes
+                    ds.lastMistakeGlobalIndex[token.text] = tokenEndGlobalIndex;
+                }
+            }
         },
         updateValidPrefixTracking: function (typedPhrase) {
             if (!this.tokens || !this.tokens.length) {
@@ -416,7 +468,7 @@ var ngramTypeConfig = {
             }
         },
         firstMismatchTokenIndex: function (typedTrim) {
-            var tokenizedTypedPhrase = this.tokenizePhrase(typedTrim);  
+            var tokenizedTypedPhrase = this.tokenizePhrase(typedTrim);
             for (var i = 0; i < this.tokens.length; i++) {
                 var token = this.tokens[i];
                 if (tokenizedTypedPhrase[i].text !== token.text) {
@@ -425,55 +477,72 @@ var ngramTypeConfig = {
             }
             return -1;
         },
+        getTokenDurationMs: function (tokenIndex) {
+            var startMs = this.tokenStartMs[tokenIndex];
+            var endMs = this.tokenEndMs[tokenIndex];
+            if (startMs == null || endMs == null || endMs - startMs <= 0) {
+                throw new Error('Invalid durationMs:', endMs - startMs, 'for token:', this.tokens[tokenIndex].text);
+            }
+            return endMs - startMs;
+        },
+        getTokenMistakeGapLength: function (tokenIndex) {
+            var lastMistakeGlobalIndex = this.dataSource.lastMistakeGlobalIndex[this.tokens[tokenIndex].text];
+            lastMistakeGlobalIndex ||= 0;
+            return this.dataSource.charsTypedCount - lastMistakeGlobalIndex;
+        },
+        getTokenCoefficientOfVariation: function (tokenIndex) {
+            var keyIntervalMs = Array(this.tokenKeyTimestampMs[tokenIndex].length - 1).fill(null);
+            for (var j = 0; j < keyIntervalMs.length; j++) {
+                keyIntervalMs[j] = this.tokenKeyTimestampMs[tokenIndex][j + 1] - this.tokenKeyTimestampMs[tokenIndex][j];
+            }
+            var meanKeyIntervalMs = keyIntervalMs.reduce((acc, b) => acc + b) / keyIntervalMs.length;
+            var varianceKeyIntervalMs = keyIntervalMs.reduce((acc, b) => acc + Math.pow(b - meanKeyIntervalMs, 2), 0) / keyIntervalMs.length;
+            var coefficientOfVariation = Math.sqrt(varianceKeyIntervalMs) / meanKeyIntervalMs;
+            // in case of a browser timing bug, we prevent the EMA from becoming NaN
+            if (isNaN(coefficientOfVariation)) {
+                coefficientOfVariation = 0;
+            }
+            return coefficientOfVariation;
+        },
         applyNgramEmaForCompletedPhrase: function () {
             var ds = this.dataSource;
-            if (!ds.ngramEmaMs) {
-                ds.ngramEmaMs = {};
-            }
-            var alpha = this.data.ema.alpha;
+            var alpha = this.data.emaLearningConfig.alpha;
             for (var i = 0; i < this.tokens.length; i++) {
                 var token = this.tokens[i];
-                var keyIntervalMs = Array(this.tokenKeyTimestampMs[i].length - 1).fill(null);
-                for (var j = 0; j < keyIntervalMs.length; j++) {
-                    keyIntervalMs[j] = this.tokenKeyTimestampMs[i][j + 1] - this.tokenKeyTimestampMs[i][j];
-                }
-                var meanKeyIntervalMs = keyIntervalMs.reduce((acc, b) => acc + b) / keyIntervalMs.length;
-                var varianceKeyIntervalMs = keyIntervalMs.reduce((acc, b) => acc + Math.pow(b - meanKeyIntervalMs, 2), 0) / keyIntervalMs.length;
-                var coefficientOfVariation = Math.sqrt(varianceKeyIntervalMs) / meanKeyIntervalMs;
-                var a = this.tokenStartMs[i];
-                var b = this.tokenEndMs[i];
-                if (a == null || b == null || b - a <= 0) {
-                    throw new Error('Invalid durationMs:', b - a, 'for token:', token.text);
-                }
-                var prev = ds.ngramEmaMs[token.text] || 0;
-                var wrong = this.tokenWrongCounts[i] || 0;
-                var mistakePenalty = this.data.ema.mistakeWeight * prev; // mistake cost is relative to the user speed
-                var consistencyPenalty = 1 + (this.data.ema.consistencyWeight * coefficientOfVariation);
-                var score = ((b - a) + wrong * mistakePenalty) * consistencyPenalty;
-                if (prev === undefined) {
-                    ds.ngramEmaMs[token.text] = score;
+                var prevScore = ds.emaScores[token.text];
+                
+                var durationMsScore = this.getTokenDurationMs(i);
+                var mistakesScore = this.getTokenMistakeGapLength(i);
+                var consistencyScore = this.getTokenCoefficientOfVariation(i);
+                if (prevScore === undefined) {
+                    ds.emaScores[token.text] = {
+                        duration: durationMsScore,
+                        mistakes: mistakesScore,
+                        consistency: consistencyScore,
+                    };
                 } else {
-                    ds.ngramEmaMs[token.text] = alpha * score + (1 - alpha) * prev;
+                    ds.emaScores[token.text] = {
+                        duration: alpha * durationMsScore + (1 - alpha) * prevScore.duration,
+                        mistakes: alpha * mistakesScore + (1 - alpha) * prevScore.mistakes,
+                        consistency: alpha * consistencyScore + (1 - alpha) * prevScore.consistency,
+                    };
                 }
             }
             this.save();
         },
         getNgramEmaCsvSorted: function () {
             var ds = this.dataSource;
-            var ema = ds.ngramEmaMs ||= {};
+            var ema = ds.emaScores || {};
             var rows = [];
-            for (var k in ema) {
-                if (Object.prototype.hasOwnProperty.call(ema, k)) {
-                    rows.push([k, Math.round(ema[k]*10)/10]);
-                }
+            for (var ngram in ema) {
+                var weights = this.getWeights(ngram);
+                rows.push([ngram, ema[ngram].duration, weights.durationFactor, ema[ngram].mistakes, weights.mistakesFactor, ema[ngram].consistency, weights.consistencyFactor, this.getCombinedWeight(ngram)]);
             }
-            rows.sort(function (a, b) {
-                return a[1] - b[1];
-            });
-            var lines = ['ngram,ema_score'];
+            rows.sort((a, b) => a[7] - b[7]);
+            var lines = ['ngram,duration,duration factor,chars since last mistake,mistake factor,consistency,consistency factor,combined weight'];
             for (var i = 0; i < rows.length; i++) {
                 lines.push(
-                    rows[i][0] + ',' + rows[i][1]
+                    rows[i][0] + ',' + rows[i][1] + ',' + rows[i][2] + ',' + rows[i][3] + ',' + rows[i][4] + ',' + rows[i][5] + ',' + rows[i][6] + ',' + rows[i][7]
                 );
             }
             return lines.join('\r\n');
@@ -618,15 +687,18 @@ var ngramTypeConfig = {
                 return;
             }
 
-            this.resumeTimer();            
-            this.updateValidPrefixTracking(typedPhrase);
-
+            this.resumeTimer();
+            if (e.inputType === 'insertText') {
+                this.dataSource.charsTypedCount += 1;
+            }
+            
             if (this.expectedPhrase.startsWith(typedPhrase)) {
                 if (this.data.soundCorrectLetterEnabled) {
                     this.stopCurrentPlayingSound();
                     this.correctLetterSound.play();
                     this.currentPlayingSound = this.correctLetterSound;
                 }
+                this.updateValidPrefixTracking(typedPhrase);
                 this.isInputCorrect = true;
                 this.hitsCorrect += 1;
             }
@@ -658,6 +730,7 @@ var ngramTypeConfig = {
                     this.hitsCorrect / (this.hitsCorrect + this.hitsWrong) * 100
                 );
 
+                this.updateMistakeTracking();
                 this.applyNgramEmaForCompletedPhrase();
 
                 var dataSource = this.dataSource;

--- a/app.js
+++ b/app.js
@@ -305,10 +305,8 @@ var ngramTypeConfig = {
             }
         },
         keyHandler: function(e) {
-            var key = e.key;
-
-            // For other miscellaneous keys.
-            if (key.length > 1) {
+            // Only handle text insertions and deletions.
+            if (e.inputType !== 'insertText' && e.inputType !== 'deleteContentBackward' && e.inputType !== 'deleteContentForward') {
                 return;
             }
 

--- a/app.js
+++ b/app.js
@@ -416,7 +416,7 @@ var ngramTypeConfig = {
             this.tokenWrongCounts = Array(n).fill(0);
             this.tokenKeyTimestampMs = Array(n);
             for (var i = 0; i < n; i++) {
-                this.tokenKeyTimestampMs[i] = Array(this.tokens[i].end + 1 - this.tokens[i].start).fill(null);
+                this.tokenKeyTimestampMs[i] = Array(this.tokens[i].end + 1 - (this.tokens[i].start - 1)).fill(null);
             }
             this.tokenStartMs = Array(n).fill(null);
             this.tokenEndMs = Array(n).fill(null);
@@ -462,9 +462,9 @@ var ngramTypeConfig = {
                 if (validIdx >= token.end && this.tokenEndMs[i] == null) {
                     this.tokenEndMs[i] = now;
                 }
-                
-                if (validIdx >= token.start && validIdx <= token.end) {
-                    this.tokenKeyTimestampMs[i][validIdx - token.start] = now;
+                // -1 because we also measure the leading time
+                if (validIdx >= token.start - 1  && validIdx <= token.end) {
+                    this.tokenKeyTimestampMs[i][validIdx - token.start + 1] = now; // +1 so the space index is not -1
                 }
             }
         },
@@ -505,6 +505,10 @@ var ngramTypeConfig = {
         },
         getTokenCoefficientOfVariation: function (tokenIndex) {
             var keyIntervalMs = Array(this.tokenKeyTimestampMs[tokenIndex].length - 1).fill(null);
+            // edge case for the first bigram in a phrase, as it only has one data point
+            if (tokenIndex === 0 && this.tokens[tokenIndex].end - this.tokens[tokenIndex].start <= 1) {
+                return null;
+            }
             for (var j = 0; j < keyIntervalMs.length; j++) {
                 keyIntervalMs[j] = this.tokenKeyTimestampMs[tokenIndex][j + 1] - this.tokenKeyTimestampMs[tokenIndex][j];
             }
@@ -531,14 +535,14 @@ var ngramTypeConfig = {
                     ds.emaScores[token.text] = {
                         duration: durationMsScore,
                         mistakes: mistakesScore,
-                        consistency: consistencyScore,
+                        consistency: consistencyScore || 0,
                     };
                 } else {
-                    ds.emaScores[token.text] = {
-                        duration: alpha * durationMsScore + (1 - alpha) * prevScore.duration,
-                        mistakes: alpha * mistakesScore + (1 - alpha) * prevScore.mistakes,
-                        consistency: alpha * consistencyScore + (1 - alpha) * prevScore.consistency,
-                    };
+                    ds.emaScores[token.text].duration = alpha * durationMsScore + (1 - alpha) * prevScore.duration;
+                    ds.emaScores[token.text].mistakes = alpha * mistakesScore + (1 - alpha) * prevScore.mistakes;
+                    if (consistencyScore !== null) {
+                        ds.emaScores[token.text].consistency = alpha * consistencyScore + (1 - alpha) * prevScore.consistency;
+                    }
                 }
             }
             this.save();

--- a/app.js
+++ b/app.js
@@ -529,6 +529,9 @@ var ngramTypeConfig = {
                 var prevScore = ds.emaScores[token.text];
                 
                 var durationMsScore = this.getTokenDurationMs(i);
+                if (this.data.source === 'custom_words' || this.data.source === 'words') {
+                    durationMsScore /= token.text.length;
+                }
                 var mistakesScore = this.getTokenMistakeGapLength(i);
                 var consistencyScore = this.getTokenCoefficientOfVariation(i);
                 if (prevScore === undefined) {

--- a/app.js
+++ b/app.js
@@ -4,7 +4,7 @@ var ngramTypeConfig = {
         return {
             // If there are major schema changes, increment this number.
             // and update the `data-reset-modal` message.
-            VERSION: 2.0,
+            VERSION: 3.0,
 
             // Data source mappings.
             bigrams: bigrams,
@@ -19,6 +19,13 @@ var ngramTypeConfig = {
                 soundIncorrectLetterEnabled: true,
                 soundPassedThresholdEnabled: true,
                 soundFailedThresholdEnabled: true,
+                lessonGenerationMode: 'random',
+                ema: {
+                    genBias: 1,
+                    alpha: 0.2,
+                    mistakeWeight: 1,
+                    consistencyWeight: 1.5,
+                },
                 bigrams: {
                     scope: 50,
                     combination: 2,
@@ -28,6 +35,7 @@ var ngramTypeConfig = {
                     WPMs: [],
                     phrases: {},
                     phrasesCurrentIndex: 0,
+                    ngramEmaMs: {},
                 },
                 trigrams: {
                     scope: 50,
@@ -38,6 +46,7 @@ var ngramTypeConfig = {
                     WPMs: [],
                     phrases: {},
                     phrasesCurrentIndex: 0,
+                    ngramEmaMs: {},
                 },
                 tetragrams: {
                     scope: 50,
@@ -48,6 +57,7 @@ var ngramTypeConfig = {
                     WPMs: [],
                     phrases: {},
                     phrasesCurrentIndex: 0,
+                    ngramEmaMs: {},
                 },
                 words: {
                     scope: 50,
@@ -58,6 +68,7 @@ var ngramTypeConfig = {
                     WPMs: [],
                     phrases: {},
                     phrasesCurrentIndex: 0,
+                    ngramEmaMs: {},
                 },
                 custom_words: {
                     scope: null,
@@ -68,6 +79,7 @@ var ngramTypeConfig = {
                     WPMs: [],
                     phrases: {},
                     phrasesCurrentIndex: 0,
+                    ngramEmaMs: {},
                 },
             },
 
@@ -117,18 +129,22 @@ var ngramTypeConfig = {
                 $('#data-reset-modal').modal('toggle');
 
                 this.refreshPhrases();
-                this.updateDataVersion()
+                this.updateDataVersion();
+                this.ensureSchemaDefaults();
             }
             else {
-                this.load()
+                this.load();
+                this.ensureSchemaDefaults();
                 var dataSource = this.dataSource;
                 this.expectedPhrase = dataSource.phrases[dataSource.phrasesCurrentIndex];
+                this.initPhraseNgramState();
             }
         }
 
         else {
             this.refreshPhrases();
-            this.updateDataVersion()
+            this.updateDataVersion();
+            this.ensureSchemaDefaults();
         }
 
         // Use jQuery instead of Vue for intercepting the <Tab>/<Esc> key.
@@ -176,6 +192,22 @@ var ngramTypeConfig = {
         'data.soundFailedThresholdEnabled': function() {
             this.save();
         },
+        'data.lessonGenerationMode': function() {
+            this.refreshPhrasesAndCurrentMetrics();
+        },
+        'data.ema.genBias': function() {
+            this.save();
+            this.refreshPhrasesAndCurrentMetrics();
+        },
+        'data.ema.alpha': function() {
+            this.save();
+        },
+        'data.ema.mistakeWeight': function() {
+            this.save();
+        },
+        'data.ema.consistencyWeight': function() {
+            this.save();
+        },
         custom_words: function() {
             this.refreshPhrasesAndCurrentMetrics();
         },
@@ -216,6 +248,268 @@ var ngramTypeConfig = {
             this.data.version = this.VERSION;
             this.save();
         },
+        ensureSchemaDefaults: function () {
+            if (
+                !this.data.lessonGenerationMode
+                || (
+                    this.data.lessonGenerationMode !== 'random'
+                    && this.data.lessonGenerationMode !== 'ema'
+                )
+            ) {
+                this.data.lessonGenerationMode = 'random';
+            }
+            this.data.ema ||= {};
+            this.data.ema.genBias ||= 1;
+            this.data.ema.alpha ||= 0.2;
+            this.data.ema.mistakeWeight ||= 1;
+            this.data.ema.consistencyWeight ||= 1.5;
+        },
+        normalizeGenerationScore: function (raw) {
+            if (
+                raw === Infinity
+                || raw === Number.POSITIVE_INFINITY
+                || typeof raw !== 'number'
+                || raw !== raw
+            ) {
+                return 1e300;
+            }
+            return Math.max(raw, 1e-9);
+        },
+        
+        getGenerationEmaScore: function (ngramStr) {
+            var ds = this.dataSource;
+            var map = ds.ngramEmaMs ||= {};
+            if (!Object.prototype.hasOwnProperty.call(map, ngramStr)) {
+                return Infinity;
+            }
+            return map[ngramStr];
+        },
+        weightedPickIndex: function (weights) {
+            var sum = 0;
+            for (var i = 0; i < weights.length; i++) {
+                sum += weights[i];
+            }
+            if (sum <= 0) {
+                return Math.floor(Math.random() * weights.length);
+            }
+            var r = Math.random() * sum;
+            var acc = 0;
+            for (var j = 0; j < weights.length; j++) {
+                acc += weights[j];
+                if (r < acc) {
+                    return j;
+                }
+            }
+            return weights.length - 1;
+        },
+        sampleNgramsWeightedNoReplace: function (pool, count) {
+            var out = [];
+            var that = this;
+            var poolCopy = pool; // no need to deep copy, we don't mutate elements
+            var take = Math.min(count, poolCopy.length);
+            for (var t = 0; t < take; t++) {
+                var weights = poolCopy.map(function (ng) {
+                    return that.normalizeGenerationScore(
+                        Math.pow(that.getGenerationEmaScore(ng), that.data.ema.genBias)
+                    );
+                });
+                var idx = this.weightedPickIndex(weights);
+                out.push(poolCopy[idx]);
+                // poolCopy.splice(idx, 1);
+            }
+            return out;
+        },
+        generatePhrasesEmaWeighted: function (numberOfItemsToCombine, repetitions) {
+            var sourceKey = this.data.source;
+            var source = this[sourceKey];
+            var scope = this.data[sourceKey].scope;
+            if (scope) {
+                source = source.slice(0, scope);
+            }
+            var pool = this.deepCopy(source);
+            if (!pool.length) {
+                return [];
+            }
+            var k = Math.min(numberOfItemsToCombine, pool.length);
+            var ngramsSublist = this.sampleNgramsWeightedNoReplace(pool, k);
+            var subPhrase = ngramsSublist.join(' ');
+            var parts = [];
+            for (var i = 0; i < repetitions; i++) {
+                parts.push(subPhrase);
+            }
+            return [parts.join(' ')];
+        },
+        tokenizePhrase: function (expectedPhrase) {
+            var tokenList = expectedPhrase.split(/\s+/).filter(function (t) {
+                return t.length > 0;
+            });
+            var tokens = [];
+            var pos = 0;
+            for (var i = 0; i < tokenList.length; i++) {
+                var token = tokenList[i];
+                tokens.push({ text: token, start: pos, end: pos + token.length - 1 });
+                pos += token.length;
+                if (i < tokenList.length - 1) {
+                    // Adds a space between tokens.
+                    pos += 1;
+                }
+            }
+            return tokens;
+        },
+        initPhraseNgramState: function () {
+            this.tokens = this.tokenizePhrase(this.expectedPhrase || '');
+            var n = this.tokens.length;
+            this.tokenWrongCounts = Array(n).fill(0);
+            this.tokenKeyTimestampMs = Array(n);
+            for (var i = 0; i < n; i++) {
+                this.tokenKeyTimestampMs[i] = Array(this.tokens[i].end + 1 - this.tokens[i].start).fill(null);
+            }
+            this.tokenStartMs = Array(n).fill(null);
+            this.tokenEndMs = Array(n).fill(null);
+            this.lastValidPrefixLength = 0;
+        },
+        updateValidPrefixTracking: function (typedPhrase) {
+            if (!this.tokens || !this.tokens.length) {
+                return;
+            }
+            if (!this.expectedPhrase.startsWith(typedPhrase)) {
+                return;
+            }
+            var validLen = typedPhrase.length;
+            if (validLen < this.lastValidPrefixLength) {
+                this.onValidPrefixShrunk(validLen);
+            } else if (validLen > this.lastValidPrefixLength) {
+                this.onValidPrefixGrown(validLen);
+            }
+            this.lastValidPrefixLength = validLen;
+        },
+        onValidPrefixGrown: function (validLen) {
+            var now = performance.now();
+            var validIdx = validLen - 1;
+            for (var i = 0; i < this.tokens.length; i++) {
+                var token = this.tokens[i];
+                // -1 because we start the timer after the leading space
+                // this has the inconvenience of starting the timer on the first character for the first ngram
+                // as it doesn't have a leading space.
+                if (validIdx >= token.start - 1 && this.tokenStartMs[i] == null) {
+                    this.tokenStartMs[i] = now;
+                }
+                if (validIdx >= token.end && this.tokenEndMs[i] == null) {
+                    this.tokenEndMs[i] = now;
+                }
+                
+                if (validIdx >= token.start && validIdx <= token.end) {
+                    this.tokenKeyTimestampMs[i][validIdx - token.start] = now;
+                }
+            }
+        },
+        onValidPrefixShrunk: function (validLen) {
+            for (var i = 0; i < this.tokens.length; i++) {
+                var token = this.tokens[i];
+                // -2 means we deleted the ngram and the leading space
+                if (validLen <= token.start - 2) {
+                    this.tokenStartMs[i] = null;
+                    this.tokenEndMs[i] = null;
+                } else if (validLen <= token.end) {
+                    this.tokenEndMs[i] = null;
+                }
+            }
+        },
+        firstMismatchTokenIndex: function (typedTrim) {
+            var tokenizedTypedPhrase = this.tokenizePhrase(typedTrim);  
+            for (var i = 0; i < this.tokens.length; i++) {
+                var token = this.tokens[i];
+                if (tokenizedTypedPhrase[i].text !== token.text) {
+                    return i;
+                }
+            }
+            return -1;
+        },
+        applyNgramEmaForCompletedPhrase: function () {
+            var ds = this.dataSource;
+            if (!ds.ngramEmaMs) {
+                ds.ngramEmaMs = {};
+            }
+            var alpha = this.data.ema.alpha;
+            for (var i = 0; i < this.tokens.length; i++) {
+                var token = this.tokens[i];
+                var keyIntervalMs = Array(this.tokenKeyTimestampMs[i].length - 1).fill(null);
+                for (var j = 0; j < keyIntervalMs.length; j++) {
+                    keyIntervalMs[j] = this.tokenKeyTimestampMs[i][j + 1] - this.tokenKeyTimestampMs[i][j];
+                }
+                var meanKeyIntervalMs = keyIntervalMs.reduce((acc, b) => acc + b) / keyIntervalMs.length;
+                var varianceKeyIntervalMs = keyIntervalMs.reduce((acc, b) => acc + Math.pow(b - meanKeyIntervalMs, 2), 0) / keyIntervalMs.length;
+                var coefficientOfVariation = Math.sqrt(varianceKeyIntervalMs) / meanKeyIntervalMs;
+                var a = this.tokenStartMs[i];
+                var b = this.tokenEndMs[i];
+                if (a == null || b == null || b - a <= 0) {
+                    throw new Error('Invalid durationMs:', b - a, 'for token:', token.text);
+                }
+                var prev = ds.ngramEmaMs[token.text] || 0;
+                var wrong = this.tokenWrongCounts[i] || 0;
+                var mistakePenalty = this.data.ema.mistakeWeight * prev; // mistake cost is relative to the user speed
+                var consistencyPenalty = 1 + (this.data.ema.consistencyWeight * coefficientOfVariation);
+                var score = ((b - a) + wrong * mistakePenalty) * consistencyPenalty;
+                if (prev === undefined) {
+                    ds.ngramEmaMs[token.text] = score;
+                } else {
+                    ds.ngramEmaMs[token.text] = alpha * score + (1 - alpha) * prev;
+                }
+            }
+            this.save();
+        },
+        getNgramEmaCsvSorted: function () {
+            var ds = this.dataSource;
+            var ema = ds.ngramEmaMs ||= {};
+            var rows = [];
+            for (var k in ema) {
+                if (Object.prototype.hasOwnProperty.call(ema, k)) {
+                    rows.push([k, Math.round(ema[k]*10)/10]);
+                }
+            }
+            rows.sort(function (a, b) {
+                return a[1] - b[1];
+            });
+            var lines = ['ngram,ema_score'];
+            for (var i = 0; i < rows.length; i++) {
+                lines.push(
+                    rows[i][0] + ',' + rows[i][1]
+                );
+            }
+            return lines.join('\r\n');
+        },
+        downloadNgramEmaCsv: function () {
+            var csv = this.getNgramEmaCsvSorted();
+            var src = this.data.source;
+            var d = new Date();
+            var pad = function (n) {
+                return (n < 10 ? '0' : '') + n;
+            };
+            var stamp =
+                d.getFullYear() +
+                '-' +
+                pad(d.getMonth() + 1) +
+                '-' +
+                pad(d.getDate());
+            var name = 'ngram-ema-' + src + '-' + stamp + '.csv';
+            var blob = new Blob([csv], {
+                type: 'text/csv;charset=utf-8;',
+            });
+            var url = URL.createObjectURL(blob);
+            var a = document.createElement('a');
+            a.href = url;
+            a.setAttribute('download', name);
+            document.body.appendChild(a);
+            a.click();
+            document.body.removeChild(a);
+            URL.revokeObjectURL(url);
+        },
+        copyNgramEmaCsv: function () {
+            var csv = this.getNgramEmaCsvSorted();
+            if (navigator.clipboard && navigator.clipboard.writeText) {
+                navigator.clipboard.writeText(csv);
+            }
+        },
         deepCopy: function(arrayOrObject) {
             var emptyArrayOrObject = $.isArray(arrayOrObject) ? [] : {};
             return $.extend(true, emptyArrayOrObject, arrayOrObject);
@@ -254,6 +548,7 @@ var ngramTypeConfig = {
             this.expectedPhrase = dataSource.phrases[0];
             dataSource.phrasesCurrentIndex = 0;
             this.save();
+            this.initPhraseNgramState();
         },
         refreshPhrasesAndCurrentMetrics: function() {
             this.refreshPhrases();
@@ -261,6 +556,13 @@ var ngramTypeConfig = {
             this.pauseTimer();
         },
         generatePhrases: function(numberOfItemsToCombine, repetitions) {
+            if (this.data.lessonGenerationMode === 'ema') {
+                return this.generatePhrasesEmaWeighted(
+                    numberOfItemsToCombine,
+                    repetitions
+                );
+            }
+
             var dataSource = this.data['source'];
             var source = this[dataSource];
             var scope = this.data[dataSource].scope
@@ -316,7 +618,8 @@ var ngramTypeConfig = {
                 return;
             }
 
-            this.resumeTimer();
+            this.resumeTimer();            
+            this.updateValidPrefixTracking(typedPhrase);
 
             if (this.expectedPhrase.startsWith(typedPhrase)) {
                 if (this.data.soundCorrectLetterEnabled) {
@@ -335,6 +638,13 @@ var ngramTypeConfig = {
                 }
                 this.isInputCorrect = false;
                 this.hitsWrong += 1;
+                var ti = this.firstMismatchTokenIndex(typedPhrase);
+                if (ti == -1) {
+                    throw new Error('all tokens matched, but the phrase is not correct');
+                }
+                if (this.tokenWrongCounts && ti < this.tokenWrongCounts.length) {
+                    this.tokenWrongCounts[ti] += 1;
+                }
             }
 
             if (typedPhrase.trimEnd() === this.expectedPhrase) {
@@ -347,6 +657,8 @@ var ngramTypeConfig = {
                 this.accuracy = Math.round(
                     this.hitsCorrect / (this.hitsCorrect + this.hitsWrong) * 100
                 );
+
+                this.applyNgramEmaForCompletedPhrase();
 
                 var dataSource = this.dataSource;
                 if (
@@ -363,9 +675,10 @@ var ngramTypeConfig = {
                     return;
                 }
 
-                // Reset WPMs when starting a new round in the same lesson.
+                // Reset WPMs when starting a new round (multi-phrase lesson). In EMA mode
+                // only one phrase exists at a time; keep a running average across phrases.
                 var newRoundStarted = (dataSource.phrasesCurrentIndex == 0);
-                if (newRoundStarted) {
+                if (newRoundStarted && this.data.lessonGenerationMode !== 'ema') {
                     dataSource.WPMs = [];
                 }
                 dataSource.WPMs.push(this.rawWPM);
@@ -384,6 +697,7 @@ var ngramTypeConfig = {
             this.hitsWrong = 0;
             this.typedPhrase = '';
             this.isInputCorrect = true;
+            this.initPhraseNgramState();
         },
         nextPhrase: function() {
             this.resetCurrentPhraseMetrics();

--- a/app.js
+++ b/app.js
@@ -311,9 +311,9 @@ var ngramTypeConfig = {
             var emaScores = this.dataSource.emaScores || {};
             if (!Object.prototype.hasOwnProperty.call(emaScores, ngram)) {
                 return {
-                    durationFactor: 1e300,
-                    mistakesFactor: 1e300,
-                    consistencyFactor: 1e300,
+                    durationFactor: Infinity,
+                    mistakesFactor: Infinity,
+                    consistencyFactor: Infinity,
                 };
             }
             var sortedDurations = Object.values(emaScores).map((score) => score.duration).sort((a, b) => a - b);
@@ -332,8 +332,20 @@ var ngramTypeConfig = {
         },
         getCombinedWeight: function (ngram) {
             var weights = this.getWeights(ngram);
-            var weight = weights.durationFactor * this.data.emaGenerationConfig.speedBias + weights.mistakesFactor * this.data.emaGenerationConfig.mistakesBias + weights.consistencyFactor * this.data.emaGenerationConfig.consistencyBias;
-            return Math.pow(weight, this.data.emaGenerationConfig.generalBias);
+            var combinedWeight = 
+                weights.durationFactor * this.data.emaGenerationConfig.speedBias + 
+                weights.mistakesFactor * this.data.emaGenerationConfig.mistakesBias + 
+                weights.consistencyFactor * this.data.emaGenerationConfig.consistencyBias;
+            return Math.min(combinedWeight, 1e300);
+        },
+        biasWeight: function (weight, minWeight, maxWeight) {
+            var span = maxWeight - minWeight;
+            if (span === 0) {
+                return weight;
+            }
+            var normalizedWeight = (weight - minWeight) / span;
+            var biasedNormalizedWeight = Math.pow(normalizedWeight, this.data.emaGenerationConfig.generalBias);
+            return biasedNormalizedWeight * span + minWeight;
         },
         weightedPickIndex: function (weights) {
             var sum = 0;
@@ -358,10 +370,11 @@ var ngramTypeConfig = {
             var that = this;
             var take = Math.min(count, pool.length);
             for (var t = 0; t < take; t++) {
-                var weights = pool.map(function (ngram) {
-                    return that.getCombinedWeight(ngram);
-                });
-                var idx = this.weightedPickIndex(weights);
+                var weights = pool.map((ngram) => that.getCombinedWeight(ngram));
+                var minWeight = Math.min(...weights);
+                var maxWeight = Math.max(...weights);
+                var biasedWeights = weights.map((weight) => that.biasWeight(weight, minWeight, maxWeight));
+                var idx = this.weightedPickIndex(biasedWeights);
                 out.push(pool[idx]);
             }
             return out;
@@ -534,9 +547,12 @@ var ngramTypeConfig = {
             var ds = this.dataSource;
             var ema = ds.emaScores || {};
             var rows = [];
+            var minCombinedWeight = Object.keys(ema).reduce((min, ngram) => Math.min(min, this.getCombinedWeight(ngram)), Infinity);
+            var maxCombinedWeight = Object.keys(ema).reduce((max, ngram) => Math.max(max, this.getCombinedWeight(ngram)), -Infinity);
             for (var ngram in ema) {
                 var weights = this.getWeights(ngram);
-                rows.push([ngram, ema[ngram].duration, weights.durationFactor, ema[ngram].mistakes, weights.mistakesFactor, ema[ngram].consistency, weights.consistencyFactor, this.getCombinedWeight(ngram)]);
+                var combinedWeight = this.biasWeight(this.getCombinedWeight(ngram), minCombinedWeight, maxCombinedWeight);
+                rows.push([ngram, ema[ngram].duration, weights.durationFactor, ema[ngram].mistakes, weights.mistakesFactor, ema[ngram].consistency, weights.consistencyFactor, combinedWeight]);
             }
             rows.sort((a, b) => a[7] - b[7]);
             var lines = ['ngram,duration,duration factor,chars since last mistake,mistake factor,consistency,consistency factor,combined weight'];

--- a/app.js
+++ b/app.js
@@ -103,6 +103,8 @@ var ngramTypeConfig = {
         },
     },
     mounted: function() {
+        $('.timer').countimer({ autoStart: false});
+        
         // If there's already saved data.
         if (localStorage.ngramTypeAppdata != undefined) {
             var data = this.getSavedData();

--- a/index.html
+++ b/index.html
@@ -321,7 +321,7 @@
                     :class="{'form-control': true, 'form-control-lg': true, 'incorrect-input': !isInputCorrect}"
                     id="input-typing" type="text" autocorrect="off" autocapitalize="none"
                     placeholder="Re-type if failed, press <TAB> or <ESC> to reset" spellcheck="false"
-                    v-on:keyup="keyHandler">
+                    v-on:input="keyHandler">
             </div>
         </div>
         <!--Lesson end-->

--- a/index.html
+++ b/index.html
@@ -237,7 +237,7 @@
                     </div>
                 </div>
             </fieldset>
-            <fieldset class="settings-module col-xl-2 col-lg-2 col-md-3 col-sm-4 col-xs-12">
+            <fieldset class="generator-settings-module col-xl-2 col-lg-2 col-md-3 col-sm-4 col-xs-12">
                 <legend>Generator</legend>
                 <div class="form-group">
                     <label class="col-form-label col-form-label-sm">Combination</label>
@@ -246,6 +246,46 @@
                     <label class="col-form-label col-form-label-sm">Repetition</label>
                     <input v-model.number="data[data['source']].repetition" v-on:change="refreshPhrases"
                         class="form-control form-control-sm" type="number" min="1">
+                    <label class="col-form-label col-form-label-sm">Lesson order</label>
+                    <div class="custom-control custom-radio">
+                        <input type="radio" class="custom-control-input" id="gen-random"
+                            name="lesson-gen-mode" value="random" v-model="data.lessonGenerationMode">
+                        <label class="custom-control-label" for="gen-random">Random shuffle</label>
+                    </div>
+                    <div class="custom-control custom-radio">
+                        <input type="radio" class="custom-control-input" id="gen-ema"
+                            name="lesson-gen-mode" value="ema" v-model="data.lessonGenerationMode">
+                        <label class="custom-control-label" for="gen-ema"
+                            title="EMA formula: (α * n-gram score + (1-α) * previous EMA)">
+                            EMA-weighted (weak / untested first)
+                        </label>
+                    </div>
+                    <div v-show="data.lessonGenerationMode === 'ema'">
+                    <label class="col-form-label col-form-label-sm mt-1"
+                        title="applies exponent to the n-gram score, meaning a value of 0 treats all n-grams equally,while a higher value favors slower n-grams. default is 1. Example: with a value of 0.6, if 'th' has a score twice as bad as 'ed', it will appear 2^0.6 = 1.52 times more often than 'ed'.">
+                        Slow n-gram bias
+                    </label>
+                    <input v-model.number="data.ema.genBias" class="form-control form-control-sm" type="number"
+                        min="0" max="2" step="0.1">
+                    <label class="col-form-label col-form-label-sm mt-1" 
+                        title="a higher value means the score depends more on recent typing performance. default is 0.2. Set to 0 to disable learning from recent typing performance.">
+                        α
+                    </label>
+                    <input v-model.number="data.ema.alpha" class="form-control form-control-sm" type="number"
+                        min="0" max="1" step="0.01">
+                    <label class="col-form-label col-form-label-sm mt-1"
+                        title="is relative to the user speed, a higher value means the score is penalized more for mistakes. default is 1.">
+                        Mistake weight
+                    </label>
+                    <input v-model.number="data.ema.mistakeWeight" class="form-control form-control-sm" type="number"
+                        min="0" max="5" step="0.1">
+                    <label class="col-form-label col-form-label-sm mt-1"
+                        title="a higher value means the score is penalized more for inconsistent typing. default is 1.5. Currently has no effect on bigrams as they only have 1 inter-key interval, meaning the variance is always 0.">
+                        Consistency weight
+                    </label>
+                    <input v-model.number="data.ema.consistencyWeight" class="form-control form-control-sm" type="number"
+                        min="0" max="2" step="0.1">
+                    </div>
                 </div>
             </fieldset>
             <fieldset class="settings-module col-xl-2 col-lg-2 col-md-3 col-sm-4 col-xs-12">
@@ -290,7 +330,7 @@
                     <div class="modal-body">
                         <p>
                             There are data schema changes to integrate the scoping of sources (i.e. the dynamic <b>Top 50</b>, <b>Top 100</b>, <b>Top 150</b>, or <b>Top 200</b>)
-                            for more flexible and comprehensive training.
+                            for more flexible and comprehensive training. The app stores per–n-gram EMA timing, optional EMA-weighted lesson order, and global EMA parameters (α, penalty).
                         </p>
                         <p>
                             This means that your saved data will be reset, but you could easily replicate your previous settings.
@@ -334,6 +374,10 @@
             <h4>WPM: {{ rawWPM }} </h4>
             &nbsp; &nbsp; &nbsp; &nbsp; <h4>Accuracy: {{ accuracy }} % </h4>
             &nbsp; &nbsp; &nbsp; &nbsp; <h4>Average WPM: {{ averageWPM }} </h4>
+        </div>
+        <div class="center small text-white-50 mt-2 mb-2">
+            <button type="button" class="btn btn-sm btn-outline-light" v-on:click="downloadNgramEmaCsv">Download n-gram EMA (CSV)</button>
+            <button type="button" class="btn btn-sm btn-outline-light ml-1" v-on:click="copyNgramEmaCsv" title="Copy ngram,ema_ms to the clipboard">Copy n-gram EMA</button>
         </div>
         <!--Stats end-->
 

--- a/index.html
+++ b/index.html
@@ -43,14 +43,6 @@
     <!-- Timer -->
     <script src="./assets/js/moment.min.js"></script>
     <script src="./assets/js/ez.countimer.js"></script>
-
-    <script>
-        $(document).ready(function() {
-            $('.timer').countimer({
-                autoStart: false,
-            });
-        });
-    </script>
 </head>
 
 <body>

--- a/index.html
+++ b/index.html
@@ -47,6 +47,9 @@
 
 <body>
     <div id="app" class="d-flex flex-column">
+        <div class="alert alert-warning text-center mb-0" role="alert" style="border-radius: 0;">
+            <strong>Development Version:</strong> Your stats may be wiped out.
+        </div>
 
         <!--Navbar (sound toggle and timer) start-->
         <nav class="navbar bg-dark justify-content-center">

--- a/index.html
+++ b/index.html
@@ -237,7 +237,7 @@
                     </div>
                 </div>
             </fieldset>
-            <fieldset class="generator-settings-module col-xl-2 col-lg-2 col-md-3 col-sm-4 col-xs-12">
+            <fieldset class="settings-module col-xl-2 col-lg-2 col-md-3 col-sm-4 col-xs-12">
                 <legend>Generator</legend>
                 <div class="form-group">
                     <label class="col-form-label col-form-label-sm">Combination</label>
@@ -246,45 +246,59 @@
                     <label class="col-form-label col-form-label-sm">Repetition</label>
                     <input v-model.number="data[data['source']].repetition" v-on:change="refreshPhrases"
                         class="form-control form-control-sm" type="number" min="1">
-                    <label class="col-form-label col-form-label-sm">Lesson order</label>
-                    <div class="custom-control custom-radio">
-                        <input type="radio" class="custom-control-input" id="gen-random"
-                            name="lesson-gen-mode" value="random" v-model="data.lessonGenerationMode">
-                        <label class="custom-control-label" for="gen-random">Random shuffle</label>
-                    </div>
-                    <div class="custom-control custom-radio">
-                        <input type="radio" class="custom-control-input" id="gen-ema"
-                            name="lesson-gen-mode" value="ema" v-model="data.lessonGenerationMode">
-                        <label class="custom-control-label" for="gen-ema"
-                            title="EMA formula: (α * n-gram score + (1-α) * previous EMA)">
-                            EMA-weighted (weak / untested first)
+                </div>
+            </fieldset>
+            <fieldset class="ema-settings-module col-xl-2 col-lg-3 col-md-4 col-sm-6 col-xs-12">
+                <legend>EMA</legend>
+                <div class="form-group">
+                    <div class="custom-control custom-checkbox">
+                        <input
+                            type="checkbox"
+                            class="custom-control-input"
+                            id="lesson-ema-enabled"
+                            :checked="data.lessonGenerationMode === 'ema'"
+                            v-on:change="data.lessonGenerationMode = $event.target.checked ? 'ema' : 'random'"
+                        >
+                        <label class="custom-control-label" for="lesson-ema-enabled"
+                            title="When disabled, lesson order is a random shuffle. When enabled, n-grams are weighted by stored EMA scores (weaker / less practiced first).">
+                            EMA-weighted lesson order
                         </label>
                     </div>
-                    <div v-show="data.lessonGenerationMode === 'ema'">
-                    <label class="col-form-label col-form-label-sm mt-1"
-                        title="applies exponent to the n-gram score, meaning a value of 0 treats all n-grams equally,while a higher value favors slower n-grams. default is 1. Example: with a value of 0.6, if 'th' has a score twice as bad as 'ed', it will appear 2^0.6 = 1.52 times more often than 'ed'.">
-                        Slow n-gram bias
-                    </label>
-                    <input v-model.number="data.ema.genBias" class="form-control form-control-sm" type="number"
-                        min="0" max="2" step="0.1">
-                    <label class="col-form-label col-form-label-sm mt-1" 
-                        title="a higher value means the score depends more on recent typing performance. default is 0.2. Set to 0 to disable learning from recent typing performance.">
-                        α
-                    </label>
-                    <input v-model.number="data.ema.alpha" class="form-control form-control-sm" type="number"
-                        min="0" max="1" step="0.01">
-                    <label class="col-form-label col-form-label-sm mt-1"
-                        title="is relative to the user speed, a higher value means the score is penalized more for mistakes. default is 1.">
-                        Mistake weight
-                    </label>
-                    <input v-model.number="data.ema.mistakeWeight" class="form-control form-control-sm" type="number"
-                        min="0" max="5" step="0.1">
-                    <label class="col-form-label col-form-label-sm mt-1"
-                        title="a higher value means the score is penalized more for inconsistent typing. default is 1.5. Currently has no effect on bigrams as they only have 1 inter-key interval, meaning the variance is always 0.">
-                        Consistency weight
-                    </label>
-                    <input v-model.number="data.ema.consistencyWeight" class="form-control form-control-sm" type="number"
-                        min="0" max="2" step="0.1">
+                    <div>
+                        <p class="ema-settings-group-label">Learning</p>
+                        <label class="col-form-label col-form-label-sm"
+                            title="Higher α: each completed phrase updates scores more from the latest attempt. Default 0.2. Use 0 to stop learning from recent performance.">
+                            α
+                        </label>
+                        <input v-model.number="data.emaLearningConfig.alpha" class="form-control form-control-sm" type="number"
+                            min="0" max="2" step="0.1">
+					</div>
+					<div v-show="data.lessonGenerationMode === 'ema'">
+                        <p class="ema-settings-group-label">Generation</p>
+                        <label class="col-form-label col-form-label-sm"
+                            title="Exponent applied to the combined weight when picking n-grams. 0 flattens differences; higher values favor targeting weaker scores. Default 1.">
+                            Overall exponent
+                        </label>
+                        <input v-model.number="data.emaGenerationConfig.generalBias" class="form-control form-control-sm" type="number"
+                            min="0" max="2" step="0.1">
+                        <label class="col-form-label col-form-label-sm"
+                            title="How much normalized duration (vs cohort) influences lesson weight. Default 1.">
+                            Speed bias
+                        </label>
+                        <input v-model.number="data.emaGenerationConfig.speedBias" class="form-control form-control-sm" type="number"
+                            min="0" max="5" step="0.1">
+                        <label class="col-form-label col-form-label-sm"
+                            title="How much normalized mistake count influences lesson weight. Default 1.">
+                            Mistakes bias
+                        </label>
+                        <input v-model.number="data.emaGenerationConfig.mistakesBias" class="form-control form-control-sm" type="number"
+                            min="0" max="5" step="0.1">
+                        <label class="col-form-label col-form-label-sm"
+                            title="How much normalized consistency influences lesson weight. Default 1.">
+                            Consistency bias
+                        </label>
+                        <input v-model.number="data.emaGenerationConfig.consistencyBias" class="form-control form-control-sm" type="number"
+                            min="0" max="5" step="0.1">
                     </div>
                 </div>
             </fieldset>
@@ -347,13 +361,16 @@
 
         <!--Lesson start-->
         <div class="px-4">
-            <div class="lesson-index center">
+            <div v-show="data.lessonGenerationMode === 'random'" class="lesson-index center">
                 <h4 v-show="data[data['source']].phrases.length">
                     Lesson {{ data[data['source']].phrasesCurrentIndex + 1 }} / {{ data[data['source']].phrases.length }}
                 </h4>
                 <h4 v-show="!data[data['source']].phrases.length">
                     Click the "Custom" link to input words.
                 </h4>
+            </div>
+            <div v-show="data.lessonGenerationMode === 'ema'" class="lesson-index center">
+                <h4></h4>
             </div>
             <div class="expected-phrase word text-white bg-primary mb-3">
                 {{ expectedPhrase }}

--- a/index.html
+++ b/index.html
@@ -280,25 +280,25 @@
                             Overall exponent
                         </label>
                         <input v-model.number="data.emaGenerationConfig.generalBias" class="form-control form-control-sm" type="number"
-                            min="0" max="2" step="0.1">
+                            min="0" max="5" step="0.1">
                         <label class="col-form-label col-form-label-sm"
                             title="How much normalized duration (vs cohort) influences lesson weight. Default 1.">
                             Speed bias
                         </label>
                         <input v-model.number="data.emaGenerationConfig.speedBias" class="form-control form-control-sm" type="number"
-                            min="0" max="5" step="0.1">
+                            min="-1" max="1" step="0.1">
                         <label class="col-form-label col-form-label-sm"
                             title="How much normalized mistake count influences lesson weight. Default 1.">
                             Mistakes bias
                         </label>
                         <input v-model.number="data.emaGenerationConfig.mistakesBias" class="form-control form-control-sm" type="number"
-                            min="0" max="5" step="0.1">
+                            min="-1" max="1" step="0.1">
                         <label class="col-form-label col-form-label-sm"
                             title="How much normalized consistency influences lesson weight. Default 1.">
                             Consistency bias
                         </label>
                         <input v-model.number="data.emaGenerationConfig.consistencyBias" class="form-control form-control-sm" type="number"
-                            min="0" max="5" step="0.1">
+                            min="-1" max="1" step="0.1">
                     </div>
                 </div>
             </fieldset>


### PR DESCRIPTION
This is only an early proposal of an idea I had from Monkeytype's weakspot funbox and [kopachef's fork of Monkeytype](https://github.com/kopachef/monkeytype/blob/25bfc23f8c5dafd71bcee6fa3ba74ca1347a3963/README.md?plain=1#L26-L33). 
I'm using an exponential moving average (EMA) to adapt generated phrases to my current weaknesses. The score of each n-gram depends on typing speed, number of mistakes, and consistency*. 
All of the parameters are user facing, with explanations on what they do in the tooltips, which is important in my eyes as I believe every user has different needs.
You can test it [here](https://sulroy.github.io/ngram-type/). I recommend using only 1 repetition and many combinations for the EMA mode, and lower the required accuracy as the algorithm will drill your mistakes automatically. 

I'm making this pull request to see if people are interested in that, and if so I will work on making a proper feature, not just a personal prototype.

*currently has no effect on bigrams, as I use the normalized variance of inter-key intervals between each character of the n-gram, but while typing this message I just thought of using some sort of ratio between the intervals and the typing speed